### PR TITLE
chore: standardize dependabot — monthly + 14d cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Managed via centralized policy rollout.
+# - monthly cadence to reduce noise
+# - 14d cooldown to mitigate supply-chain attacks (malicious versions yanked within days)
+# Security updates remain immediate.
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,3 @@
-# Managed via centralized policy rollout.
-# - monthly cadence to reduce noise
-# - 14d cooldown to mitigate supply-chain attacks (malicious versions yanked within days)
-# Security updates remain immediate.
 version: 2
 updates:
   - package-ecosystem: "docker"
@@ -10,17 +6,9 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 14
-      semver-patch-days: 14
-    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 14
-      semver-patch-days: 14
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Standardizes Dependabot **version updates** across all repos:

- **Cadence:** monthly (reduces PR noise)
- **Cooldown:** 14 days on major/minor/patch (mitigates supply-chain attacks where a malicious version is published and yanked within days)
- **Ecosystems:** `github-actions` + auto-detected from manifest files in this repo

Security updates remain immediate (the cooldown setting only affects version updates).

Generated by automated rollout.
